### PR TITLE
Exercises must `sbt compile` at CI stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
 - oraclejdk8
 
 script:
-- sbt test
+- sbt compile test
 
 after_success:
 - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then sbt


### PR DESCRIPTION
... to be aware about potential issues, like in this case :P . I've just realized about it :(

This is needed because the compile task has been overridden.

In this case, we'll see that master branch is broken :P

As side note, this is happening also in the rest of the exercises libraries.

CC @raulraja @dialelo 