### PR TITLE
Remove + in BatchingSection.scala

### DIFF
--- a/src/main/scala/fetchlib/BatchingSection.scala
+++ b/src/main/scala/fetchlib/BatchingSection.scala
@@ -34,7 +34,7 @@ object BatchingSection extends FlatSpec with Matchers with Section {
    * When implementing it we can specify the maximum size of the batched requests to this data source,
    * let’s try it out:
    *
-   * {{{+
+   * {{{
    *
    * implicit object BatchedUserSource extends DataSource[UserId, User]{
    * override def name = "BatchedUser"


### PR DESCRIPTION
The formatting of this tutorial when rendered in ScalaExercises.org was broken. I think it may have been because of this + sign.